### PR TITLE
Always compact ETCD before evaluating reclaimable space

### DIFF
--- a/maintenance/etcd/defrag.sh
+++ b/maintenance/etcd/defrag.sh
@@ -6,6 +6,9 @@ first_endpoint=$(echo $ETCDCTL_ENDPOINTS | cut -d',' -f1)
 
 echo $first_endpoint
 
+rev=$(ETCDCTL_ENDPOINTS="${first_endpoint}" etcdctl endpoint status --write-out="json" | egrep -o '"revision":[0-9]*' | egrep -o '[0-9]*')
+etcdctl compact --command-timeout 60s --physical $rev
+
 diff=$(ETCDCTL_ENDPOINTS="${first_endpoint}" etcdctl endpoint status --write-out=json | jq -r '.[] | .Status.dbSize - .Status.dbSizeInUse')
 ondisk=$(ETCDCTL_ENDPOINTS="${first_endpoint}" etcdctl endpoint status --write-out=json | jq -r '.[] | .Status.dbSize')
 
@@ -19,14 +22,8 @@ echo "Fragmented Space: ${fragmentedSpace} MB"
 
 # Perform defragmentation and compaction if needed
 if [ "$fragmentedPercentage" -ge "$fragmentationThreshold" ] || [ "$fragmentedSpace" -ge 1024 ]; then
-    if [ "$fragmentedSpace" -ge 1024 ]; then
-        rev=$(ETCDCTL_ENDPOINTS="${first_endpoint}" etcdctl endpoint status --write-out="json" | egrep -o '"revision":[0-9]*' | egrep -o '[0-9]*')
-        etcdctl compact $rev
-        etcdctl defrag --command-timeout 30s
-    else
-        echo "Fragmentation is above threshold, performing defragmentation..."
-    fi
-    etcdctl defrag --command-timeout 30s
+    echo "Fragmentation is above threshold, performing defragmentation..."
+    etcdctl defrag --command-timeout 60s
 else
     echo "No compaction and defragmentation needed."
 fi


### PR DESCRIPTION
The problem was that we did not compact ETCD before evaluating how much space can bee reclaimed. Most of the time, the reclaimable space is not beyond threshold leading to ETCD going above 80% use and triggering ETCD shield to deny PipelineRun.

Always perform compaction, which does not have a penalty, i.e. does not cause ETCD member from being unavailable for a few minutes like defrag. Pass the --physical option to wait for compaction to finish before moving to evaluation of reclaimable space. Then evaluate base if defrag is needed, as it was done before.

Also simplify the defrag conditions, no need to have nested if, we want to defrag if we are above 15% fragmentation or if 1GB can be reclaimed.

KFLUXINFRA-1644