### PR TITLE
Added 'COPY . .' to make all the prefetched dependencies available in…

### DIFF
--- a/maintenance/etcd/Dockerfile
+++ b/maintenance/etcd/Dockerfile
@@ -9,6 +9,9 @@ COPY build-deps/go.mod build-deps/go.sum ./
 # Download dependencies
 RUN go mod download
 
+# Copy source
+COPY . .
+
 # Build etcdctl
 RUN go build -o etcdctl go.etcd.io/etcd/etcdctl/v3
 


### PR DESCRIPTION
## What
Added `COPY . .` to make all the prefetched dependencies available in the container.

## Why
The build is failing in [Konflux release pipeline](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/etcd-defrag/pipelineruns/managed-fxfcx?releaseName=etcd-defrag-2zn9g-d565c29-q76h9). It's probably happening  because the Dockerfile doesn't copy the prefetched modules (hence the PR) and then the go mod download tries to download files (because it's not in the container itself) from untrusted package sources when hermetic build is enabled.