### PR TITLE
KFLUXINFRA-2561: Fix hermetic build for etcd-defrag

### DIFF
--- a/.tekton/defrag-pull-request.yaml
+++ b/.tekton/defrag-pull-request.yaml
@@ -33,7 +33,7 @@ spec:
   - name: hermetic
     value: "true"
   - name: prefetch-input
-    value: '[{"type": "rpm", "path": "maintenance/etcd/build-deps"}, {"type": "gomod", "path": "maintenance/etcd/build-deps"}]'
+    value: '[{"type": "gomod", "path": "maintenance/etcd/build-deps"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/defrag-push.yaml
+++ b/.tekton/defrag-push.yaml
@@ -30,7 +30,7 @@ spec:
   - name: hermetic
     value: "true"
   - name: prefetch-input
-    value: '[{"type": "rpm", "path": "maintenance/etcd/build-deps"}, {"type": "gomod", "path": "maintenance/etcd/build-deps"}]'
+    value: '[{"type": "gomod", "path": "maintenance/etcd/build-deps"}]'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/maintenance/etcd/Dockerfile
+++ b/maintenance/etcd/Dockerfile
@@ -17,8 +17,6 @@ FROM registry.redhat.io/ubi9:9.7-1762180182
 
 ADD defrag.sh /opt/
 
-RUN dnf -y install jq && dnf clean all
-
 # Copy etcdctl from builder
 COPY --from=build /build/etcdctl /usr/bin/etcdctl
 

--- a/maintenance/etcd/build-deps/rpms.lock.yaml
+++ b/maintenance/etcd/build-deps/rpms.lock.yaml
@@ -1,8 +1,0 @@
-lockfileVersion: 1
-lockfileVendor: redhat
-arches:
-  - arch: x86_64
-    packages:
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/j/jq-1.6-19.el9.x86_64.rpm
-      - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/oniguruma-6.9.6-1.el9.5.x86_64.rpm
-

--- a/maintenance/etcd/defrag.sh
+++ b/maintenance/etcd/defrag.sh
@@ -13,8 +13,10 @@ echo $first_endpoint
 rev=$(ETCDCTL_ENDPOINTS="${first_endpoint}" etcdctl endpoint status --write-out="json" | egrep -o '"revision":[0-9]*' | egrep -o '[0-9]*')
 etcdctl compact --command-timeout 60s --physical $rev
 
-diff=$(ETCDCTL_ENDPOINTS="${first_endpoint}" etcdctl endpoint status --write-out=json | jq -r '.[] | .Status.dbSize - .Status.dbSizeInUse')
-ondisk=$(ETCDCTL_ENDPOINTS="${first_endpoint}" etcdctl endpoint status --write-out=json | jq -r '.[] | .Status.dbSize')
+status_json=$(ETCDCTL_ENDPOINTS="${first_endpoint}" etcdctl endpoint status --write-out=json)
+ondisk=$(echo "$status_json" | grep -oE '"dbSize":[0-9]*' | head -1 | grep -oE '[0-9]*')
+inuse=$(echo "$status_json" | grep -oE '"dbSizeInUse":[0-9]*' | head -1 | grep -oE '[0-9]*')
+diff=$((ondisk - inuse))
 
 # Calculate fragmented percentage
 fragmentedPercentage=$(( ${diff} * 100 / ${ondisk} ))

--- a/maintenance/etcd/test-defrag.sh
+++ b/maintenance/etcd/test-defrag.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Test script for defrag.sh extraction logic
+# Verifies grep extraction produces expected results
+#
+
+set -e
+
+echo "=== Testing extraction logic ==="
+echo ""
+
+# Mock etcdctl endpoint status output
+# To regenerate this mock data, run:
+#
+#   # Start etcd
+#   podman run -d --name etcd-test -p 2379:2379 \
+#       quay.io/coreos/etcd:v3.5.18 \
+#       /usr/local/bin/etcd \
+#       --advertise-client-urls http://0.0.0.0:2379 \
+#       --listen-client-urls http://0.0.0.0:2379
+#
+#   # Get the JSON output
+#   podman run --rm --network host quay.io/coreos/etcd:v3.5.18 \
+#       etcdctl --endpoints=http://localhost:2379 endpoint status --write-out=json
+#
+#   # Cleanup
+#   podman stop etcd-test && podman rm etcd-test
+#
+MOCK_STATUS='[{"Endpoint":"http://localhost:2379","Status":{"header":{"cluster_id":14841639068965178418,"member_id":10276657743932975437,"revision":1,"raft_term":2},"version":"3.5.18","dbSize":20480,"leader":10276657743932975437,"raftIndex":4,"raftTerm":2,"raftAppliedIndex":4,"dbSizeInUse":16384}}]'
+
+# Expected values from mock data
+EXPECTED_REVISION=1
+EXPECTED_DBSIZE=20480
+EXPECTED_DBSIZEINUSE=16384
+EXPECTED_DIFF=4096
+
+echo "Mock JSON:"
+echo "$MOCK_STATUS"
+echo ""
+
+#######################################
+# Extract using grep (same as defrag.sh)
+#######################################
+echo "=== Extracting with grep ==="
+revision=$(echo "$MOCK_STATUS" | grep -oE '"revision":[0-9]*' | grep -oE '[0-9]*')
+dbSize=$(echo "$MOCK_STATUS" | grep -oE '"dbSize":[0-9]*' | head -1 | grep -oE '[0-9]*')
+dbSizeInUse=$(echo "$MOCK_STATUS" | grep -oE '"dbSizeInUse":[0-9]*' | head -1 | grep -oE '[0-9]*')
+diff=$((dbSize - dbSizeInUse))
+
+echo "  revision:    $revision"
+echo "  dbSize:      $dbSize"
+echo "  dbSizeInUse: $dbSizeInUse"
+echo "  diff:        $diff"
+echo ""
+
+#######################################
+# Assert against expected values
+#######################################
+echo "=== Validating results ==="
+errors=0
+
+if [ "$revision" = "$EXPECTED_REVISION" ]; then
+    echo "✅ revision: $revision (expected: $EXPECTED_REVISION)"
+else
+    echo "❌ revision: $revision (expected: $EXPECTED_REVISION)"
+    errors=$((errors + 1))
+fi
+
+if [ "$dbSize" = "$EXPECTED_DBSIZE" ]; then
+    echo "✅ dbSize: $dbSize (expected: $EXPECTED_DBSIZE)"
+else
+    echo "❌ dbSize: $dbSize (expected: $EXPECTED_DBSIZE)"
+    errors=$((errors + 1))
+fi
+
+if [ "$dbSizeInUse" = "$EXPECTED_DBSIZEINUSE" ]; then
+    echo "✅ dbSizeInUse: $dbSizeInUse (expected: $EXPECTED_DBSIZEINUSE)"
+else
+    echo "❌ dbSizeInUse: $dbSizeInUse (expected: $EXPECTED_DBSIZEINUSE)"
+    errors=$((errors + 1))
+fi
+
+if [ "$diff" = "$EXPECTED_DIFF" ]; then
+    echo "✅ diff: $diff (expected: $EXPECTED_DIFF)"
+else
+    echo "❌ diff: $diff (expected: $EXPECTED_DIFF)"
+    errors=$((errors + 1))
+fi
+
+echo ""
+if [ $errors -eq 0 ]; then
+    echo "✅ All tests passed!"
+    exit 0
+else
+    echo "❌ $errors test(s) failed!"
+    exit 1
+fi


### PR DESCRIPTION
## What
1. Changed data extraction logic in `defrag.sh` to use `grep` command instead of `jq`.
2. Created test file for `defrag.sh` using a mock endpoint status extracted from `quay.io/coreos/etcd:v3.5.18` image with `etcdctl` and `podman`
3. Removed all the associated files and references that used `jq` to enable the hermetic build. 

## Why
1. Enable an hermetic build. When we use `jq` and enable hermetic build, the [build pipeline in Konflux](https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rhtap-releng-tenant/applications/etcd-defrag/pipelineruns/managed-fxfcx/) fails the **verify-conforma** check because `jq` package source (`https://cdn-ubi.redhat.com`) isn't among the allowed package sources:

- https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
- https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem
- https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem

2. Simplify `defrag.sh` and the Dockerfile
3. Validate the suggested change. 

## Validation
The output from running the new `test-defrag.sh`:
```
=== Testing extraction logic ===

Mock JSON:
[{"Endpoint":"http://localhost:2379","Status":{"header":{"cluster_id":14841639068965178418,"member_id":10276657743932975437,"revision":1,"raft_term":2},"version":"3.5.18","dbSize":20480,"leader":10276657743932975437,"raftIndex":4,"raftTerm":2,"raftAppliedIndex":4,"dbSizeInUse":16384}}]

=== Extracting with grep ===
  revision:    1
  dbSize:      20480
  dbSizeInUse: 16384
  diff:        4096

=== Validating results ===
✅ revision: 1 (expected: 1)
✅ dbSize: 20480 (expected: 20480)
✅ dbSizeInUse: 16384 (expected: 16384)
✅ diff: 4096 (expected: 4096)

✅ All tests passed!
```