### PR TITLE
KFLUXINFRA-3200 - Raise etcd defrag thresholds above cluster-etcd-operator defaults

### DIFF
--- a/maintenance/etcd/defrag.sh
+++ b/maintenance/etcd/defrag.sh
@@ -2,10 +2,8 @@
 
 set -x
 
-diskUsageThreshold=${diskUsageThreshold:-60}
-fragmentationThreshold=${fragmentationThreshold:-30}
-reclaimSpaceThreshold=${reclaimSpaceThreshold:-1024}
-
+maxFragmentedPercentage=${maxFragmentedPercentage:-50}
+minDefragMB=${minDefragMB:-120}
 first_endpoint=$(echo $ETCDCTL_ENDPOINTS | cut -d',' -f1)
 
 echo $first_endpoint
@@ -24,16 +22,7 @@ echo "Fragmented Percentage: ${fragmentedPercentage}%"
 fragmentedSpace=$(( ${diff} / 1024 / 1024 ))
 echo "Fragmented Space: ${fragmentedSpace} MB"
 
-diskUsage=$((${ondisk} * 100 / (8 * 1024 * 1024 * 1024)))
-echo "Disk Usage: ${diskUsage}"
-
-# Perform defragmentation if needed
-if [ "$diskUsage" -lt "$diskUsageThreshold" ]; then
-    echo "Disk usage is below threshold, no defragmentation needed."
-    exit 0
-fi
-
-if [ "$fragmentedPercentage" -ge "$fragmentationThreshold" ] || [ "$fragmentedSpace" -ge "$reclaimSpaceThreshold" ]; then
+if [ "$fragmentedPercentage" -ge "$maxFragmentedPercentage" ] && [ "$fragmentedSpace" -ge "$minDefragMB" ]; then
     echo "Fragmentation is above threshold, performing defragmentation..."
     etcdctl defrag --command-timeout 60s
 else


### PR DESCRIPTION
## What
Align defrag.sh thresholds with the upstream OpenShift cluster-etcd-operator defrag controller so this script acts as a stricter safety net that only triggers after the operator would have already acted.

## Comparison

| Threshold | etcd-operator | etcd-shield (defrag.sh) |
|---|---|---|
| [maxFragmentedPercentage](https://github.com/openshift/cluster-etcd-operator/blob/main/pkg/operator/defragcontroller/defragcontroller.go#L31) | 45% | 50% |
| [minDefragBytes](https://github.com/openshift/cluster-etcd-operator/blob/main/pkg/operator/defragcontroller/defragcontroller.go#L29) | 100 MB | 120 MB |
| [Condition logic](https://github.com/openshift/cluster-etcd-operator/blob/main/pkg/operator/defragcontroller/defragcontroller.go#L304) | `fragmentation >= 45% AND dbSize >= 100MB` | `fragmentation >= 50% AND reclaimableSpace >= 120MB` |
| [Sync interval](https://github.com/openshift/cluster-etcd-operator/blob/main/pkg/operator/defragcontroller/defragcontroller.go#L78) | ~11 min (`compactionInterval` 10m + 1m) | CronJob-defined (10m staging/5m production) |