### PR TITLE
Add Renovate configuration with weekly schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "timezone": "UTC",
+  "schedule": [
+    "before 7am on Monday"
+  ],
+  "minimumReleaseAge": "3 days"
+}


### PR DESCRIPTION
Add initial Renovate configuration with a weekly schedule (Monday morning) and a 3-day minimum release age filter. This reduces PR noise and avoids picking up broken releases that get yanked shortly after publishing.

Contributes to: KFLUXINFRA-3008