### PR TITLE
KFLUXINFRA-3534 - Revert etcd defrag thresholds to original values

### DIFF
--- a/maintenance/etcd/defrag.sh
+++ b/maintenance/etcd/defrag.sh
@@ -2,8 +2,10 @@
 
 set -x
 
-maxFragmentedPercentage=${maxFragmentedPercentage:-50}
-minDefragMB=${minDefragMB:-120}
+diskUsageThreshold=${diskUsageThreshold:-60}
+fragmentationThreshold=${fragmentationThreshold:-30}
+reclaimSpaceThreshold=${reclaimSpaceThreshold:-1024}
+
 first_endpoint=$(echo $ETCDCTL_ENDPOINTS | cut -d',' -f1)
 
 echo $first_endpoint
@@ -22,7 +24,16 @@ echo "Fragmented Percentage: ${fragmentedPercentage}%"
 fragmentedSpace=$(( ${diff} / 1024 / 1024 ))
 echo "Fragmented Space: ${fragmentedSpace} MB"
 
-if [ "$fragmentedPercentage" -ge "$maxFragmentedPercentage" ] && [ "$fragmentedSpace" -ge "$minDefragMB" ]; then
+diskUsage=$((${ondisk} * 100 / (8 * 1024 * 1024 * 1024)))
+echo "Disk Usage: ${diskUsage}"
+
+# Perform defragmentation if needed
+if [ "$diskUsage" -lt "$diskUsageThreshold" ]; then
+    echo "Disk usage is below threshold, no defragmentation needed."
+    exit 0
+fi
+
+if [ "$fragmentedPercentage" -ge "$fragmentationThreshold" ] || [ "$fragmentedSpace" -ge "$reclaimSpaceThreshold" ]; then
     echo "Fragmentation is above threshold, performing defragmentation..."
     etcdctl defrag --command-timeout 60s
 else


### PR DESCRIPTION
## What
Reverts commit [3608c74](https://github.com/redhat-appstudio/infrastructure/commit/3608c740a458720d930baacf07ba10c1596b5210) which raised etcd defrag thresholds above cluster-etcd-operator defaults, restoring the original three-threshold approach with disk usage gate and OR logic.

## Why
We had multiple incidents where the built-in etcd-operator failed to defrag when etcd quota usage was very close to its limit. Reverting to the original, more aggressive thresholds ensures our script acts as a reliable safety net.

## Validation
Verified there is no diff between the current `defrag.sh` and the version from the commit before the reverted one. You can verify it like that: 
```
gh pr checkout 115
git diff 3608c740a458720d930baacf07ba10c1596b5210~1 -- maintenance/etcd/defrag.sh
```
Nothing should be printed after the `git diff` is executed.