### PR TITLE
KFLUXINFRA-3596: Update target directory for rover group sync grps

### DIFF
--- a/maintenance/rover-group-sync/README.md
+++ b/maintenance/rover-group-sync/README.md
@@ -7,8 +7,8 @@ Bash script intended to run in a Kubernetes CronJob (see `Dockerfile`) It:
 1. **Validates** that `oc`, `yq` (mikefarah v4), and `git` are available, and that required paths and environment variables are present.
 2. **Prepares LDAP sync config** by copying the LDAP sync template and injecting `LDAP_PASSWORD`, `LDAP_DN`, and the CA path with `yq` in-place edits.
 3. **Clones** the target Git repository (branch from `GIT_BRANCH`, default `main`) into a work directory.
-4. **Syncs OpenShift Groups from LDAP** with `oc adm groups sync`, normalizes the `List` output with `yq`, and writes **one YAML file per group** under `groups/<ENVIRONMENT>/`, using a filename derived from `metadata.name` (non-alphanumeric characters sanitized with `sed`).
-5. **Commits and pushes** only if `groups/<ENVIEONMENT>` changed; otherwise exits successfully without a commit.
+4. **Syncs OpenShift Groups from LDAP** with `oc adm groups sync`, normalizes the `List` output with `yq`, and writes **one YAML file per group** under `components/rover-group-sync/<ENVIRONMENT>/groups`, using a filename derived from `metadata.name` (non-alphanumeric characters sanitized with `sed`).
+5. **Commits and pushes** only if `components/rover-group-sync/<ENVIRONMENT>/groups` changed; otherwise exits successfully without a commit.
 
 Typical inputs are mounted files (`SYNC_CONFIG_SOURCE`, `LDAP_CA_PATH`, `GIT_REPO_SSH_PATH`) and secrets (`GIT_REPO_URL`, `LDAP_DN`, `LDAP_PASSWORD`, `GIT_PUBLIC_SSH_KEY`). For Git over SSH, the script sets **`StrictHostKeyChecking=yes`** and writes a **temporary `known_hosts`** file whose line is `github.com` plus the key type and base64 key read from **`GIT_SSH_PUBLIC_KEY`**. Do not disable host key verification in production.
 

--- a/maintenance/rover-group-sync/sync-rover-groups.sh
+++ b/maintenance/rover-group-sync/sync-rover-groups.sh
@@ -114,8 +114,8 @@ echo "Retrieving groups from LDAP..."
 COUNT="$("${YQ}" '.items | length' "${LIST_TMP}")"
 
 # Create Group manifests in target directory (and sanitize the group name)
-echo "Creating Group manifests in target ${ENVIRONMENT} directory..."
-TARGET_DIR="${WORKDIR}/groups/${ENVIRONMENT}"
+echo "Creating Group manifests in target ${ENVIRONMENT} groups directory..."
+TARGET_DIR="${WORKDIR}/components/rover-group-sync/${ENVIRONMENT}/groups/"
 mkdir -p "${TARGET_DIR}"
 "${FIND}" "${TARGET_DIR}" -maxdepth 1 -type f -name '*.yaml' -delete
 
@@ -127,8 +127,8 @@ while [[ "${i}" -lt "${COUNT}" ]]; do
     i=$((i + 1))
 done
 
-# Commit to Git repo if the groups were updated
-"${GIT}" add "groups"
+# Commit to Git repo if the groups were updated (must match TARGET_DIR tree)
+"${GIT}" add "${TARGET_DIR}"
 if "${GIT}" diff --cached --quiet; then
     echo "No group manifest changes; skipping commit."
     exit 0

--- a/maintenance/rover-group-sync/test/stubs/find-and-delete-fail
+++ b/maintenance/rover-group-sync/test/stubs/find-and-delete-fail
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
-# Delegates to real find(1) except the rover-group-sync cleanup of groups/*.yaml.
+# Delegates to real find(1) except the rover-group-sync cleanup of *.yaml under
+# components/rover-group-sync/<ENVIRONMENT>/groups/.
 REAL_FIND="$(command -v find)"
 [[ -n "${REAL_FIND}" ]] || { echo "stub find: real find not on PATH" >&2; exit 99; }
 
 target="${1:-}"
-# Script runs find on groups/<ENVIRONMENT>/ (e.g. groups/staging), not groups/ itself.
-if [[ "$(basename -- "$(dirname -- "${target}")")" == "groups" ]] && [[ "$*" == *"-name"* ]] && [[ "$*" == *"-delete"* ]]; then
+# Strip trailing slash so basename is stable.
+normalized="${target%/}"
+# Script runs: find "${TARGET_DIR}" -maxdepth 1 -type f -name '*.yaml' -delete
+# TARGET_DIR is .../components/rover-group-sync/<staging|production>/groups
+if [[ "$(basename -- "${normalized}")" == "groups" ]] &&
+  [[ "${normalized}" == *"/components/rover-group-sync/"* ]] &&
+  [[ "$*" == *"-name"* ]] &&
+  [[ "$*" == *"-delete"* ]]; then
   echo "find: simulated failure deleting existing group yaml files" >&2
   exit 1
 fi

--- a/maintenance/rover-group-sync/test/sync-rover-groups.bats
+++ b/maintenance/rover-group-sync/test/sync-rover-groups.bats
@@ -276,7 +276,7 @@ stub_binaries() {
 
 # --- existing group files deletion failure
 
-@test "fails when deleting existing group yaml files under groups/ fails" {
+@test "fails when deleting existing group yaml files under groups directory fails" {
   [[ -n "$(command -v yq)" ]] || skip "yq not installed"
   [[ -n "$(command -v git)" ]] || skip "git not installed"
   [[ -n "$(command -v find)" ]] || skip "find not installed"
@@ -386,8 +386,8 @@ stub_binaries() {
   run bash "${SCRIPT}"
   [[ "${status}" -eq 0 ]]
 
-  [[ -f "${WORKDIR}/groups/staging/test-group.yaml" ]]
-  run yq '.metadata.name' "${WORKDIR}/groups/staging/test-group.yaml"
+  [[ -f "${WORKDIR}/components/rover-group-sync/staging/groups/test-group.yaml" ]]
+  run yq '.metadata.name' "${WORKDIR}/components/rover-group-sync/staging/groups/test-group.yaml"
   [[ "${output}" == "test-group" ]]
 
   run git -C "${bare}" log --oneline -1
@@ -410,17 +410,17 @@ stub_binaries() {
   run bash "${SCRIPT}"
   [[ "${status}" -eq 0 ]]
 
-  [[ -f "${WORKDIR}/groups/staging/rover-alpha.yaml" ]]
-  [[ -f "${WORKDIR}/groups/staging/rover-bravo.yaml" ]]
+  [[ -f "${WORKDIR}/components/rover-group-sync/staging/groups/rover-alpha.yaml" ]]
+  [[ -f "${WORKDIR}/components/rover-group-sync/staging/groups/rover-bravo.yaml" ]]
 
-  run yq '.metadata.name' "${WORKDIR}/groups/staging/rover-alpha.yaml"
+  run yq '.metadata.name' "${WORKDIR}/components/rover-group-sync/staging/groups/rover-alpha.yaml"
   [[ "${output}" == "rover-alpha" ]]
-  run yq '.users | length' "${WORKDIR}/groups/staging/rover-alpha.yaml"
+  run yq '.users | length' "${WORKDIR}/components/rover-group-sync/staging/groups/rover-alpha.yaml"
   [[ "${output}" == "0" ]]
 
-  run yq '.metadata.name' "${WORKDIR}/groups/staging/rover-bravo.yaml"
+  run yq '.metadata.name' "${WORKDIR}/components/rover-group-sync/staging/groups/rover-bravo.yaml"
   [[ "${output}" == "rover-bravo" ]]
-  run yq '.users[0]' "${WORKDIR}/groups/staging/rover-bravo.yaml"
+  run yq '.users[0]' "${WORKDIR}/components/rover-group-sync/staging/groups/rover-bravo.yaml"
   [[ "${output}" == "user-one" ]]
 }
 
@@ -447,8 +447,8 @@ stub_binaries() {
   run bash "${SCRIPT}"
   [[ "${status}" -eq 0 ]]
 
-  [[ -f "${WORKDIR}/groups/staging/test-group.yaml" ]]
-  run yq '.metadata.name' "${WORKDIR}/groups/staging/test-group.yaml"
+  [[ -f "${WORKDIR}/components/rover-group-sync/staging/groups/test-group.yaml" ]]
+  run yq '.metadata.name' "${WORKDIR}/components/rover-group-sync/staging/groups/test-group.yaml"
   [[ "${output}" == "test-group" ]]
 
   run git -C "${bare}" log --oneline -1 my-branch
@@ -473,8 +473,8 @@ stub_binaries() {
   run bash "${SCRIPT}"
   [[ "${status}" -eq 0 ]]
 
-  [[ -f "${WORKDIR}/groups/production/test-group.yaml" ]]
-  run yq '.metadata.name' "${WORKDIR}/groups/production/test-group.yaml"
+  [[ -f "${WORKDIR}/components/rover-group-sync/production/groups/test-group.yaml" ]]
+  run yq '.metadata.name' "${WORKDIR}/components/rover-group-sync/production/groups/test-group.yaml"
   [[ "${output}" == "test-group" ]]
 
   run git -C "${bare}" log --oneline -1
@@ -498,8 +498,8 @@ stub_binaries() {
   [[ "${status}" -eq 0 ]]
 
   # konflux:weird/name -> colon and slash become underscores (see sync-rover-groups.sh sed)
-  [[ -f "${WORKDIR}/groups/staging/konflux_weird_name.yaml" ]]
-  run yq '.metadata.name' "${WORKDIR}/groups/staging/konflux_weird_name.yaml"
+  [[ -f "${WORKDIR}/components/rover-group-sync/staging/groups/konflux_weird_name.yaml" ]]
+  run yq '.metadata.name' "${WORKDIR}/components/rover-group-sync/staging/groups/konflux_weird_name.yaml"
   [[ "${output}" == "konflux:weird/name" ]]
 }
 


### PR DESCRIPTION
Change the target directory for rover group sync group manifests to be under the components/rover-group-sync/groups/ directory.