### PR TITLE
Keep LDAP labels/annotations in rover group sync

### DIFF
--- a/maintenance/rover-group-sync/sync-rover-groups.sh
+++ b/maintenance/rover-group-sync/sync-rover-groups.sh
@@ -114,12 +114,25 @@ fi
 "${GIT}" clone --depth 1 --branch "${BRANCH}" "${GIT_REPO_URL}" "${WORKDIR}"
 cd "${WORKDIR}"
 
-# Get all Group objects - portable only (no annotations/labels/cluster metadata)
+# Get Group objects with minimal metadata; keep openshift.io/ldap* labels/annotations for LDAP sync provenance
 GROUP_LIST_TMP="$(mktemp)"
 
 echo "Retrieving groups from LDAP..."
 "${OC}" adm groups sync --sync-config="${SYNC_CONFIG_FILE}" -o yaml | "${YQ}" \
-    '.items |= map({"apiVersion": .apiVersion, "kind": .kind, "metadata": {"name": .metadata.name}, "users": (.users // [])})' \
+    '.items |= map({
+      "apiVersion": .apiVersion,
+      "kind": .kind,
+      "metadata": (
+        {"name": .metadata.name}
+        + ({"labels": (.metadata.labels // {}
+            | with_entries(select(.key | test("^openshift\\.io/ldap"))))}
+          | select(.labels | length > 0))
+        + ({"annotations": (.metadata.annotations // {}
+            | with_entries(select(.key | test("^openshift\\.io/ldap"))))}
+          | select(.annotations | length > 0))
+      ),
+      "users": (.users // [])
+    })' \
     >"${GROUP_LIST_TMP}"
 
 COUNT="$("${YQ}" '.items | length' "${GROUP_LIST_TMP}")"

--- a/maintenance/rover-group-sync/test/stubs/stub-oc
+++ b/maintenance/rover-group-sync/test/stubs/stub-oc
@@ -3,6 +3,7 @@
 #   single          — one Group (test-group)
 #   multi           — multiple Groups rover-alpha, rover-bravo
 #   sanitize        — one Group with a name to be sanitized (konflux:weird/name
+#   ldap-metadata   — one Group with openshift.io/ldap* labels/annotations plus noise
 #   sync-fail       — sync exits 1 (LDAP/API error)
 #   malformed-yaml  — stdout is not valid YAML (breaks the yq pipe)
 #   empty           — valid List with items: [] (no groups)
@@ -20,6 +21,11 @@ items:
   - apiVersion: user.openshift.io/v1
     kind: Group
     metadata:
+      annotations:
+        openshift.io/ldap.uid: stuff-and-things
+        openshift.io/ldap.url: ldaps://ldap.corp.redhat.com
+      labels:
+        openshift.io/ldap.host: ldap.corp.redhat.com
       name: test-group
     users:
       - user1
@@ -34,11 +40,21 @@ items:
   - apiVersion: user.openshift.io/v1
     kind: Group
     metadata:
+      annotations:
+        openshift.io/ldap.uid: stuff-and-things
+        openshift.io/ldap.url: ldaps://ldap.corp.redhat.com
+      labels:
+        openshift.io/ldap.host: ldap.corp.redhat.com
       name: rover-alpha
     users: []
   - apiVersion: user.openshift.io/v1
     kind: Group
     metadata:
+      annotations:
+        openshift.io/ldap.uid: stuff-and-things
+        openshift.io/ldap.url: ldaps://ldap.corp.redhat.com
+      labels:
+        openshift.io/ldap.host: ldap.corp.redhat.com
       name: rover-bravo
     users:
       - user-one
@@ -53,7 +69,33 @@ items:
   - apiVersion: user.openshift.io/v1
     kind: Group
     metadata:
+      annotations:
+        openshift.io/ldap.uid: stuff-and-things
+        openshift.io/ldap.url: ldaps://ldap.corp.redhat.com
       name: konflux:weird/name
+      labels:
+        openshift.io/ldap.host: ldap.corp.redhat.com
+    users:
+      - sync-test-user
+EOF
+    exit 0
+    ;;
+  ldap-metadata)
+    cat <<'EOF'
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: user.openshift.io/v1
+    kind: Group
+    metadata:
+      name: konflux-admins
+      labels:
+        openshift.io/ldap.host: ldap.corp.redhat.com
+        app.kubernetes.io/managed-by: manual
+      annotations:
+        openshift.io/ldap.uid: cn=konflux-admins,ou=adhoc,ou=managedGroups,dc=redhat,dc=com
+        openshift.io/ldap.url: ldaps://ldap.corp.redhat.com
+        kubectl.kubernetes.io/last-applied-configuration: '{"kind":"Group"}'
     users:
       - sync-test-user
 EOF
@@ -76,7 +118,7 @@ EOF
     exit 0
     ;;
   *)
-    echo "stub oc: set CASE to single, multi, sanitize, sync-fail, malformed-yaml, or empty" >&2
+    echo "stub oc: set CASE to single, multi, sanitize, ldap-metadata, sync-fail, malformed-yaml, or empty" >&2
     exit 99
     ;;
 esac

--- a/maintenance/rover-group-sync/test/sync-rover-groups.bats
+++ b/maintenance/rover-group-sync/test/sync-rover-groups.bats
@@ -511,6 +511,69 @@ stub_binaries() {
   [[ "${output}" == *"chore(groups): sync $ENVIRONMENT rover LDAP groups"* ]]
 }
 
+@test "preserves openshift.io/ldap labels and annotations in group manifests" {
+  [[ -n "$(command -v yq)" ]] || skip "yq not installed"
+  [[ -n "$(command -v git)" ]] || skip "git not installed"
+  [[ -n "$(command -v kustomize)" ]] || skip "kustomize not installed"
+
+  export CASE=ldap-metadata
+  export OC="${BATS_TEST_DIRNAME}/stubs/stub-oc"
+  chmod +x "${OC}"
+  export GIT_SSH_COMMAND="true"
+
+  bare="$(mktemp -d)/remote.git"
+  init_bare_repo_with_empty_commit "${bare}"
+  export GIT_REPO_URL="file://${bare}"
+
+  run bash "${SCRIPT}"
+  [[ "${status}" -eq 0 ]]
+
+  manifest="${WORKDIR}/components/k8s-groups/staging/rover/groups/konflux-admins.yaml"
+  [[ -f "${manifest}" ]]
+
+  run yq '.metadata.labels."openshift.io/ldap.host"' "${manifest}"
+  [[ "${output}" == "ldap.corp.redhat.com" ]]
+
+  run yq '.metadata.annotations."openshift.io/ldap.uid"' "${manifest}"
+  [[ "${output}" == "cn=konflux-admins,ou=adhoc,ou=managedGroups,dc=redhat,dc=com" ]]
+
+  run yq '.metadata.annotations."openshift.io/ldap.url"' "${manifest}"
+  [[ "${output}" == "ldaps://ldap.corp.redhat.com" ]]
+}
+
+@test "strips non-openshift.io/ldap labels and annotations from group manifests" {
+  [[ -n "$(command -v yq)" ]] || skip "yq not installed"
+  [[ -n "$(command -v git)" ]] || skip "git not installed"
+  [[ -n "$(command -v kustomize)" ]] || skip "kustomize not installed"
+
+  export CASE=ldap-metadata
+  export OC="${BATS_TEST_DIRNAME}/stubs/stub-oc"
+  chmod +x "${OC}"
+  export GIT_SSH_COMMAND="true"
+
+  bare="$(mktemp -d)/remote.git"
+  init_bare_repo_with_empty_commit "${bare}"
+  export GIT_REPO_URL="file://${bare}"
+
+  run bash "${SCRIPT}"
+  [[ "${status}" -eq 0 ]]
+
+  manifest="${WORKDIR}/components/k8s-groups/staging/rover/groups/konflux-admins.yaml"
+  [[ -f "${manifest}" ]]
+
+  run yq '.metadata.labels | has("app.kubernetes.io/managed-by")' "${manifest}"
+  [[ "${output}" == "false" ]]
+
+  run yq '.metadata.annotations | has("kubectl.kubernetes.io/last-applied-configuration")' "${manifest}"
+  [[ "${output}" == "false" ]]
+
+  run yq '.metadata.labels | length' "${manifest}"
+  [[ "${output}" == "1" ]]
+
+  run yq '.metadata.annotations | length' "${manifest}"
+  [[ "${output}" == "2" ]]
+}
+
 @test "syncs groups, writes manifests, commits and pushes with multiple groups" {
   [[ -n "$(command -v yq)" ]] || skip "yq not installed"
   [[ -n "$(command -v git)" ]] || skip "git not installed"
@@ -672,7 +735,7 @@ stub_binaries() {
   [[ "${output}" == "Kustomization" ]]
 
   run git -C "${bare}" log --oneline -1
-  [[ "${output}" == *"chore(groups): sync rover LDAP groups"* ]]
+  [[ "${output}" == *"chore(groups): sync $ENVIRONMENT rover LDAP groups"* ]]
 }
 
 @test "exits 0 without commit when manifests are unchanged" {

--- a/maintenance/rover-group-sync/test/test_helpers.bash
+++ b/maintenance/rover-group-sync/test/test_helpers.bash
@@ -5,15 +5,21 @@ init_bare_repo_with_empty_commit() {
   local bare="$1"
   local no_hooks
   no_hooks="$(mktemp -d)"
+  # CI runners often have no global user.name/user.email; use repo-local identity.
+  local -a git_test_identity=(
+    -c "user.email=rover-group-sync@test"
+    -c "user.name=rover-group-sync-test"
+  )
   git init --bare -b main "${bare}"
   local tmp
   tmp="$(mktemp -d)"
   (
     cd "${tmp}" || exit 1
     git init -b main
-    git -c "core.hooksPath=${no_hooks}" commit --allow-empty -m "init"
+    git "${git_test_identity[@]}" -c "core.hooksPath=${no_hooks}" \
+      commit --allow-empty -m "init"
     git remote add origin "file://${bare}"
-    git push -u origin main
+    git "${git_test_identity[@]}" push -u origin main
   )
   rm -rf "${tmp}" "${no_hooks}"
 }


### PR DESCRIPTION
The Rover Group Sync script is currently failing to sync groups it created because it does not include the LDAP labels/annotations in the Groups. This commit ensures that the LDAP labels/annotations are included.