### PR TITLE
Remove sync-time annotation from Group objects

### DIFF
--- a/maintenance/rover-group-sync/sync-rover-groups.sh
+++ b/maintenance/rover-group-sync/sync-rover-groups.sh
@@ -114,12 +114,24 @@ fi
 "${GIT}" clone --depth 1 --branch "${BRANCH}" "${GIT_REPO_URL}" "${WORKDIR}"
 cd "${WORKDIR}"
 
-# Get all Group objects - portable only (no annotations/labels/cluster metadata)
+# Get Group objects with minimal metadata; keep openshift.io/ldap* labels/annotations except sync-time (changes every run)
 GROUP_LIST_TMP="$(mktemp)"
-
 echo "Retrieving groups from LDAP..."
 "${OC}" adm groups sync --sync-config="${SYNC_CONFIG_FILE}" -o yaml | "${YQ}" \
-    '.items |= map({"apiVersion": .apiVersion, "kind": .kind, "metadata": {"name": .metadata.name}, "users": (.users // [])})' \
+    '.items |= map({
+      "apiVersion": .apiVersion,
+      "kind": .kind,
+      "metadata": (
+        {"name": .metadata.name}
+        + ({"labels": (.metadata.labels // {}
+            | with_entries(select(.key | test("^openshift\\.io/ldap"))))}
+          | select(.labels | length > 0))
+        + ({"annotations": (.metadata.annotations // {}
+            | with_entries(select(.key | test("^openshift\\.io/ldap") and .key != "openshift.io/ldap.sync-time")))}
+          | select(.annotations | length > 0))
+      ),
+      "users": (.users // [])
+    })' \
     >"${GROUP_LIST_TMP}"
 
 COUNT="$("${YQ}" '.items | length' "${GROUP_LIST_TMP}")"

--- a/maintenance/rover-group-sync/test/stubs/stub-oc
+++ b/maintenance/rover-group-sync/test/stubs/stub-oc
@@ -21,6 +21,11 @@ items:
     kind: Group
     metadata:
       name: test-group
+      labels:
+        openshift.io/ldap.host: ldap.corp.redhat.com
+      annotations:
+        openshift.io/ldap.uid: cn=test-group,ou=adhoc,ou=managedGroups,dc=redhat,dc=com
+        openshift.io/ldap.url: ldap.corp.redhat.com:636
     users:
       - user1
 EOF
@@ -35,11 +40,21 @@ items:
     kind: Group
     metadata:
       name: rover-alpha
+      labels:
+        openshift.io/ldap.host: ldap.corp.redhat.com
+      annotations:
+        openshift.io/ldap.uid: cn=rover-alpha,ou=adhoc,ou=managedGroups,dc=redhat,dc=com
+        openshift.io/ldap.url: ldap.corp.redhat.com:636
     users: []
   - apiVersion: user.openshift.io/v1
     kind: Group
     metadata:
       name: rover-bravo
+      labels:
+        openshift.io/ldap.host: ldap.corp.redhat.com
+      annotations:
+        openshift.io/ldap.uid: cn=rover-bravo,ou=adhoc,ou=managedGroups,dc=redhat,dc=com
+        openshift.io/ldap.url: ldap.corp.redhat.com:636
     users:
       - user-one
 EOF
@@ -54,6 +69,11 @@ items:
     kind: Group
     metadata:
       name: konflux:weird/name
+      labels:
+        openshift.io/ldap.host: ldap.corp.redhat.com
+      annotations:
+        openshift.io/ldap.uid: cn=konflux:weird/name,ou=adhoc,ou=managedGroups,dc=redhat,dc=com
+        openshift.io/ldap.url: ldap.corp.redhat.com:636
     users:
       - sync-test-user
 EOF

--- a/maintenance/rover-group-sync/test/sync-rover-groups.bats
+++ b/maintenance/rover-group-sync/test/sync-rover-groups.bats
@@ -672,7 +672,7 @@ stub_binaries() {
   [[ "${output}" == "Kustomization" ]]
 
   run git -C "${bare}" log --oneline -1
-  [[ "${output}" == *"chore(groups): sync rover LDAP groups"* ]]
+  [[ "${output}" == *"chore(groups): sync $ENVIRONMENT rover LDAP groups"* ]]
 }
 
 @test "exits 0 without commit when manifests are unchanged" {


### PR DESCRIPTION
Remove sync-time annotation from Group objects to avoid unnecessary diffs and thus commits in the Git repository.