### PR TITLE
docs(KFLUXINFRA-3762): Address agentready Tiers 1 & 2 recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,13 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Editor and IDE files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Per-user Claude settings
+.claude/settings.local.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: detect-private-key
+
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: 2491238703a5d3415bb2b7ff11388bf775372f29 # v0.10.0
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: 79a6b2b1392eaf49cdd32ac4f14be1a809bbd8f7 # v1.37.1
+    hooks:
+      - id: yamllint
+        args: [-s]
+
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: 9aa1e0e7b353dca419a08d3abd2e9f5a0978c383 # v1.99.2
+    hooks:
+      - id: terraform_fmt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,12 @@ rover-group-sync:
 | Lint    | `shellcheck maintenance/rover-group-sync/sync-rover-groups.sh` |
 | Test    | `bats maintenance/rover-group-sync/test/`                      |
 
+Pre-commit:
+| Action  | Command                                       |
+|---------|-----------------------------------------------|
+| Setup   | `pip install pre-commit && pre-commit install` |
+| Run all | `pre-commit run --all-files`                   |
+
 ### Single-File Verification
 
 - Terraform format: `terraform fmt path/to/file.tf`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,13 @@ rover-group-sync:
 | Lint    | `shellcheck maintenance/rover-group-sync/sync-rover-groups.sh` |
 | Test    | `bats maintenance/rover-group-sync/test/`                      |
 
+### Single-File Verification
+
+- Terraform format: `terraform fmt path/to/file.tf`
+- Shell lint: `shellcheck path/to/script.sh`
+- YAML lint: `yamllint path/to/file.yaml`
+- BATS test single: `bats path/to/test_file.bats`
+
 ## Project Layout
 
 Terraform module (located at `terraform/modules/`):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # infrastructure
+
+Miscellaneous infrastructure components for Konflux: Terraform modules for cloud networking and OIDC, maintenance scripts (etcd defrag, Rover group sync), and Tekton pipeline definitions.
+
+## Prerequisites
+
+- Terraform >= 1.x (for `terraform/modules/`)
+- Docker or Podman (for building maintenance containers)
+- shellcheck (for linting shell scripts)
+- BATS (for running rover-group-sync tests)
+
+## Usage
+
+See [AGENTS.md](AGENTS.md) for quick commands, project layout, and development conventions.
+
+## Components
+
+- **terraform/modules/** — Terraform modules for networking and OIDC provider
+- **maintenance/etcd/** — etcd defragmentation container
+- **maintenance/rover-group-sync/** — Rover group synchronization container with BATS tests
+- **.tekton/** — Konflux pipeline definitions for container builds


### PR DESCRIPTION
- Expand README, add CLAUDE.md and single-file vwrification
- Expand README.md with overview, prerequisites, usage link to AGENTS.md, and component listing. Add CLAUDE.md pointer. Add single-file verification commands to AGENTS.md for terraform, shellcheck, yamllint, and BATS.
- Add .pre-commit-config.yaml with shellcheck, yamllint, terraform_fmt,  and standard hooks (trailing-whitespace, detect-private-key, etc.).
- Add editor/IDE patterns and .claude/settings.local.json to .gitignore.

Addresses AgentReady Tier 1 & 2 findings